### PR TITLE
Run 'apt-get update' before any 'apt-get install'

### DIFF
--- a/modules/00-start.sh
+++ b/modules/00-start.sh
@@ -81,5 +81,5 @@ service rsyslog restart
 ### AWS
 echo Install few packages
 # install shared tools
-apt-get -y --force-yes install joe git awscli
 apt-get -y --force-yes update
+apt-get -y --force-yes install joe git awscli


### PR DESCRIPTION
The sources list can list state/corrupt apt sources that will result in a 404 if we don't refresh this list first with an apt-get update
