### PR TITLE
Update vars to provide options for salt and docker configs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 # PyBuilder
 target/
 *~
+
+# Pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -10,22 +10,25 @@ Provisions VM with:
 
 Setups filesystem:
 - /srv (btrfs: as raid0 of all available ephemeral volumes - only if available)
-- /data (ext4: as attached ebs volume - only if available)
+- /data (nfs or attached ebs volume(ext4) - only if needed)
 
 
 configuration
 =============
+- salt_standalone - configure to run without salt master
 - is_saltmaster - is host a salt master or minion
 - has_data_storage - have you attached ebs volume?
 - opg_role - sets opg-role grain to this value (to be deprecated in favour to aws tags)
-- docker_engine_version - docker engine version to install
-- docker_compose_version - what docker compose version to install
+- docker_engine_version - docker engine version to install (will install latest version if not set)
+- docker_compose_version - what docker compose version to install (will install latest version if not set)
+- use_nfs_data - use nfs to persist container data.
 - salt_version - what salt version to install
+- salt_s3_path - The s3 path for masterless salt operation
 
 
 attached volume
 ===============
-Assumes that ebs volume is attached at /dev/sdh or /dev/xvdh
+Assumes that ebs volume is attached at /dev/sdh or /dev/xvdh.  If this is a node for and ECS cluster, there will be an NFS mount for /data.
 
 
 how to use it

--- a/README.md
+++ b/README.md
@@ -15,20 +15,22 @@ Setups filesystem:
 
 configuration
 =============
-- salt_standalone - configure to run without salt master
-- is_saltmaster - is host a salt master or minion
-- has_data_storage - have you attached ebs volume?
-- opg_role - sets opg-role grain to this value (to be deprecated in favour to aws tags)
-- docker_engine_version - docker engine version to install (will install latest version if not set)
-- docker_compose_version - what docker compose version to install (will install latest version if not set)
-- use_nfs_data - use nfs to persist container data.
-- salt_version - what salt version to install
-- salt_s3_path - The s3 path for masterless salt operation
-
+- USE_SALT - whether to install salt
+- SALT_STANDALONE - configure to run without salt master
+- IS_SALTMASTER - is host a salt master or minion
+- SALT_VERSION - what salt version to install
+- SALT_S3_PATH - The s3 path for masterless salt operation
+- HAS_DATA_STORAGE - have you attached ebs volume?
+- USE_DOCKER - whether to install docker
+- DOCKER_ENGINE_VERSION - docker engine version to install (will install latest version if not set)
+- DOCKER_COMPOSE_VERSION - what docker compose version to install (will install latest version if not set)
+- DOCKER_NFS_DATA - use nfs to persist container data.
+- OPG_ROLE - sets opg-role grain to this value (to be deprecated in favour to aws tags)
+- OPG_STACK - sets opg-stack grain to this value
 
 attached volume
 ===============
-Assumes that ebs volume is attached at /dev/sdh or /dev/xvdh.  If this is a node for and ECS cluster, there will be an NFS mount for /data.
+Assumes that ebs volume is attached at /dev/sdh or /dev/xvdh.  If this is a node for and ECS cluster, there will be an NFS mount on /nfsdata.
 
 
 how to use it
@@ -56,7 +58,6 @@ resource "template_file" "user_data_monitoring" {
         is_saltmaster = "no"
         has_data_storage = "yes"
         opg_role = "monitoring"
-
         salt_version = "${var.salt_version}"
         docker_engine_version = "${var.docker_engine_version}"
         docker_compose_version = "${var.docker_compose_version}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,9 +5,10 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 function download()
 {
     #try downloading a file for 5 mins
+    #if you want to use a branch of the bootstrap repo, set the BS_BRANCH variable in userdata
     local module_path="${1}"
     local retry_count_down=30
-    while ! wget --no-verbose --retry-connrefused --random-wait -O "${module_path}" "https://raw.githubusercontent.com/ministryofjustice/opg-bootstrap/OPGOPS-1166/${module_path}" && [ ${retry_count_down} -gt 0 ] ; do
+    while ! wget --no-verbose --retry-connrefused --random-wait -O "${module_path}" "https://raw.githubusercontent.com/ministryofjustice/opg-bootstrap/${BS_BRANCH:-master}/${module_path}" && [ ${retry_count_down} -gt 0 ] ; do
         retry_count_down=$((retry_count_down - 1))
         sleep 10
     done

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,9 +5,9 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 function download()
 {
     #try downloading a file for 5 mins
-    local module_path=$${1}
+    local module_path="${1}"
     local retry_count_down=30
-    while ! wget --no-verbose --retry-connrefused --random-wait -O $${module_path} https://raw.githubusercontent.com/ministryofjustice/opg-bootstrap/master/$${module_path} && [ $${retry_count_down} -gt 0 ] ; do
+    while ! wget --no-verbose --retry-connrefused --random-wait -O "${module_path}" "https://raw.githubusercontent.com/ministryofjustice/opg-bootstrap/OPGOPS-1166/${module_path}" && [ ${retry_count_down} -gt 0 ] ; do
         retry_count_down=$((retry_count_down - 1))
         sleep 10
     done
@@ -15,26 +15,24 @@ function download()
 
 function module()
 {
-    local module_path=$${1}
-    if [ ! -e $${module_path} ]; then
-        echo $${module_path}: Downloading
+    local module_path="${1}"
+    if [ ! -e "${module_path}" ]; then
+        echo "${module_path}: Downloading"
         mkdir -p modules
-        wget --no-verbose --retry-connrefused --random-wait -O $${module_path} https://raw.githubusercontent.com/ministryofjustice/opg-bootstrap/master/$${module_path}
+        download "${module_path}"
     fi
-    echo $${module_path}: Loading
-    source $${module_path}
+    echo "${module_path}: Loading"
+    source "${module_path}"
 }
-
-readonly IS_SALTMASTER=${is_saltmaster}
-readonly HAS_DATA_STORAGE=${has_data_storage}
-readonly OPG_ROLE=${opg_role}
-
-readonly SALT_VERSION=${salt_version}
-readonly DOCKER_ENGINE_VERSION=$(docker_engine_version}
-readonly DOCKER_COMPOSE_VERSION=${docker_compose_version}
 
 module modules/00-start.sh
 module modules/10-volumes.sh
-module modules/20-docker.sh
-module modules/90-salt.sh
+if [ "${USE_DOCKER}" == "yes" ]
+then
+    module modules/20-docker.sh
+fi
+if [ "${USE_SALT}" == "yes" ]
+then
+    module modules/90-salt.sh
+fi
 module modules/99-end.sh

--- a/modules/00-start.sh
+++ b/modules/00-start.sh
@@ -1,85 +1,93 @@
-echo "BEGIN: `TZ=UTC date`"
-
-# fail on 1st failure
-set -e
-
+#!/usr/bin/env bash
+set -x
+echo "BEGIN: $(TZ=UTC date)"
 export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 export DEBIAN_FRONTEND=noninteractive
 readonly EC2_METADATA_URL='http://169.254.169.254/latest/meta-data'
 
+#Setup hosts file
+echo "Updating hostname"
+# domain name and resolv.conf ar managed through dhcp
+IP=$(curl -s "${EC2_METADATA_URL}/local-ipv4")
+echo "${IP} ${HOSTNAME} ${OPG_ROLE}" >> /etc/hosts
+
+
 # Make sure files are 644 and directories are 755.
 umask 022
 
-
+if [[ "${USE_SALT}" == "yes" ]]
+then
 ################################################### salt stop
-echo Ensuring salt is stopped
-# Need to stop Salt services.
-for s in salt-{minion,master}; do
-    if [[ -f /etc/init/${s}.conf ]]; then
-        service $s stop || true
+    echo "Ensuring salt is stopped"
+    # Need to stop Salt services.
+    for s in salt-{minion,master}; do
+        if [[ -f /etc/init/${s}.conf ]]; then
+            service $s stop || true
 
-        # Stop with extreme prejudice.
-        if pgrep -f $s &>dev/null; then
-            pkill -9 -f $s
+            # Stop with extreme prejudice.
+            if pgrep -f $s &>dev/null; then
+                pkill -9 -f $s
+            fi
+
+            # Purge any keys and/or SSL certificates
+            # that might have linger behind.
+            rm -rf /etc/salt/pki/${s##*-}
         fi
+    done
 
-        # Purge any keys and/or SSL certificates
-        # that might have linger behind.
-        rm -rf /etc/salt/pki/${s##*-}
-    fi
-done
+    # Make sure that Minion will pick his new ID to
+    # advertise use after the new host name was set.
+    rm -f /etc/salt/minion_id
 
-# Make sure that Minion will pick his new ID to
-# advertise use after the new host name was set.
-rm -f /etc/salt/minion_id
-
-# Make sure to remove any cache left by Salt, etc.
-rm -rf /var/{cache,log,run}/salt/*
-
-
-################################################### docker stop
-echo Ensuring docker is stopped
-# Need to stop Docker in order to make sure that
-# the /srv/docker is not in use, as often "aufs"
-# and "devicemapper" drivers will be active on
-# boot causing "device or resource busy" errors.
-if docker --version &>/dev/null; then
-    service docker stop || true
-
-    # Disable the Docker service and switch it
-    # off completely if requested to do so.
-    if [[ $DISABLE_DOCKER == 'yes' ]]; then
-        for f in /etc/init/docker.conf /etc/init.d/docker; do
-            dpkg-divert --rename $f
-        done
-
-        update-rc.d -f docker disable || true
-    else
-        DOCKER='yes'
-    fi
+    # Make sure to remove any cache left by Salt, etc.
+    rm -rf /var/{cache,log,run}/salt/*
 fi
 
 
+if [ "${USE_DOCKER}" == "yes" ]
+then
+################################################### docker stop
+    echo "Ensuring docker is stopped"
+    # Need to stop Docker in order to make sure that
+    # the /srv/docker is not in use, as often "aufs"
+    # and "devicemapper" drivers will be active on
+    # boot causing "device or resource busy" errors.
+    if docker --version &>/dev/null; then
+        service docker stop || true
 
-################################################### hostname
-echo Updating hostname
-# domain name and resolv.conf ar managed through dhcp
-IP=$(curl -s ${EC2_METADATA_URL}/local-ipv4)
-AWS_HOSTNAME=`hostname`
-HOSTNAME="${OPG_ROLE}-${AWS_HOSTNAME}"
+        # Disable the Docker service and switch it
+        # off completely if requested to do so.
+        if [[ "${DISABLE_DOCKER}" == 'yes' ]]; then
+            for f in /etc/init/docker.conf /etc/init.d/docker; do
+                dpkg-divert --rename $f
+            done
 
-echo "${IP} ${HOSTNAME} ${OPG_ROLE} ${AWS_HOSTNAME}" >> /etc/hosts
-echo $HOSTNAME | tee \
-    /proc/sys/kernel/hostname \
-    /etc/hostname
-hostname -F /etc/hostname
+            update-rc.d -f docker disable || true
+        else
+            export DOCKER='yes'
+        fi
+    fi
+fi
 
-# let's restart rsyslog to catchup with new hostname
-service rsyslog restart
+#set default bash prompt
+echo "Setting custom bash prompt"
+cat <<'EOF' > /etc/profile.d/bash-prompt.sh
 
+if [[ ${EUID} == 0 ]]
+then
+        PS1="${PS1}\w #\[\033[00m\]"
+else
+        PS1="${PS1}\w $\[\033[00m\]"
+fi
+EOF
+OPG_STACK=$(echo "${OPG_STACK}"| tr -d '[:digit:]')
+if [  "${OPG_STACK}" == "production" ]
+then
+    sed -i "1s/^/PS1=\"\\\[\\\033[01;31m\\\](${OPG_STACK}) \\\u@${OPG_ROLE}:\"\n/" /etc/profile.d/bash-prompt.sh
+else
+    sed -i "1s/^/PS1=\"\\\[\\\033[01;34m\\\](${OPG_STACK}) \\\u@${OPG_ROLE}:\"\n/" /etc/profile.d/bash-prompt.sh
+fi
 
-### AWS
-echo Install few packages
-# install shared tools
-apt-get -y --force-yes update
-apt-get -y --force-yes install joe git awscli
+echo "Install support packages"
+apt-get -y -qq update
+apt-get -y -qq install joe git awscli

--- a/modules/00-start.sh
+++ b/modules/00-start.sh
@@ -44,7 +44,7 @@ then
 fi
 
 
-if [ "${USE_DOCKER}" == "yes" ]
+if [[ "${USE_DOCKER}" == "yes" ]]
 then
 ################################################### docker stop
     echo "Ensuring docker is stopped"
@@ -81,7 +81,7 @@ else
 fi
 EOF
 OPG_STACK=$(echo "${OPG_STACK}"| tr -d '[:digit:]')
-if [  "${OPG_STACK}" == "production" ]
+if [[ "${OPG_STACK}" =~ ^production ]]
 then
     sed -i "1s/^/PS1=\"\\\[\\\033[01;31m\\\](${OPG_STACK}) \\\u@${OPG_ROLE}:\"\n/" /etc/profile.d/bash-prompt.sh
 else

--- a/modules/20-docker.sh
+++ b/modules/20-docker.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
+set -e
 
 # install docker
-echo Installing Docker
+echo "Installing Docker"
 
 #as key server fails once a while...
 #apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 
 #...we are shipping the repository key ourselves
-apt-key add - <<EOF
+apt-key add - <<'EOF'
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
 
@@ -42,10 +43,18 @@ EOF
 
 
 echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
-apt-get update
-apt-get install -y docker-engine=${DOCKER_ENGINE_VERSION:-"1.9.1-*"}
 
-curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION:-"1.5.2"}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+apt-get -y -qq update
+
+if [[ "x${DOCKER_ENGINE_VERSION}" == "x" ]]
+then
+    apt-get install -y -qq docker-engine
+else
+    apt-get install -y -qq docker-engine="${DOCKER_ENGINE_VERSION}"
+fi
+
+curl -s -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION:-'1.6.2'}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
+
 chmod +x /usr/local/bin/docker-compose
 
 echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --ipv6=false --log-driver=syslog\"" >> /etc/default/docker

--- a/modules/99-end.sh
+++ b/modules/99-end.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 touch /var/run/opg-user-data-done
-echo "END: `TZ=UTC date`"
+echo "END: $(TZ=UTC date)"


### PR DESCRIPTION
Add logic to run modules only when needed
Modify bootstrap to use download function

Remove $$ reference until understood

Change wget path to use branch

Update bash prompt

Update variable in bash prompt script to prevent expansion of variables at install time.

Update apt-get command to remove force-yes and add -qq to suppress output

Apply fixes as per shellcheck
Update inline variables in heredoc.
General clena for consistency.

Update bash prompt script heredoc for variable expansion

Update sed command to insert PS1.

This custom prompt is not working on ubuntu 15.04 due to PS1 being set
in teh /etc/skel/.bashrcfile.

Add -x for debugging.
Update prompt to include working directory name.

Update docker-compase version to 1.6.2

Update readme with changes

Add s3 sync and salt-call for masterless salt

Remove config branch variable as the brnach will be in the userdata already

Remove extra - in pip command for salt

Remove EOT quotes to allow variable expansion in heredoc

Add region to aws command. Fix name of opg_role grain

Add nfs mount tasks
