### PR TITLE
set MTU variable when var is set

### DIFF
--- a/modules/00-start.sh
+++ b/modules/00-start.sh
@@ -37,7 +37,7 @@ for s in salt-{minion,master}; do
         service $s stop || true
 
         # Stop with extreme prejudice.
-        if pgrep -f $s &>dev/null; then
+        if pgrep -f $s &> /dev/null; then
             pkill -9 -f $s
         fi
 
@@ -93,7 +93,7 @@ EOF
 
 if grep -q "^prepend domain-name" /etc/dhcp/dhclient.conf
 then
-    sed -i 's/^prepend domain-name.*/prepend domain-name " '${OPG_STACKNAME}'.internal ;"/' /etc/dhcp/dhclient.conf
+    sed -i 's/^prepend domain-name.*/prepend domain-name "'${OPG_STACKNAME}'.internal";/' /etc/dhcp/dhclient.conf
 else
     echo "prepend domain-name  \"${OPG_STACKNAME}.internal \";" >> /etc/dhcp/dhclient.conf
 fi

--- a/modules/00-start.sh
+++ b/modules/00-start.sh
@@ -98,7 +98,15 @@ else
     echo "prepend domain-name  \"${OPG_STACKNAME}.internal \";" >> /etc/dhcp/dhclient.conf
 fi
 
+
 #make runtime change to affect above config
 ifdown eth0 && ifup eth0
 #sed -i 's/^search/search '${OPG_STACKNAME}'.internal/' /etc/resolv.conf
+
+if [ -n "${ETH0_MTU}" ]; then
+# set MTU if variable is defined
+	ip link set dev eth0 mtu ${ETH0_MTU}
+fi
+
+
 

--- a/modules/90-salt.sh
+++ b/modules/90-salt.sh
@@ -119,6 +119,8 @@ else
     # Start salt minion
     #make sysv scripts link to upstart
     rm -f /etc/init.d/salt-minion
+    # to stop insserv: script salt-minion is not an executable regular file, skipped! on 16.04
+    chmod +x /etc/init/salt-minion.conf
     ln -s /etc/init/salt-minion.conf /etc/init.d/salt-minion
     rm -f /etc/init/salt-minion.override
     update-rc.d salt-minion defaults || systemctl enable salt-minion


### PR DESCRIPTION
This adds the required cloud-init block to set the MTU value on ETH0 when the env variable `ETH0_MTU` is available

note that this is being applied to spectrum-deployment-branch 