### PR TITLE
Added check for contents in /sys/class/scsi_host

### DIFF
--- a/modules/10-volumes.sh
+++ b/modules/10-volumes.sh
@@ -28,10 +28,13 @@ sed -i -e \
     /etc/fstab
 
 
-echo Scaning SCSI bus to look for new devices
-for b in /sys/class/scsi_host/*/scan; do
-    echo '- - -' > "${b}"
-done
+if [ "$(ls -A /sys/class/scsi_host)" ];
+then
+    echo Scaning SCSI bus to look for new devices
+    for b in /sys/class/scsi_host/*/scan; do
+        echo '- - -' > "${b}"
+    done
+fi
 
 echo Refreshing partition table for each block device.
 for b in $(lsblk -dno NAME | awk '!/(sr.*|mapper|loop)/ { print $1 }'); do


### PR DESCRIPTION
Was failing to bootstrap on a `c5.4xlarge` instance due to the `/sys/class/scsi_host` directory being empty